### PR TITLE
Log error message on runner failure

### DIFF
--- a/lib/karma.test_runner.js
+++ b/lib/karma.test_runner.js
@@ -22,6 +22,6 @@ _.filter(context.keys(), filter).forEach(function(path) {
     context(path);
   } catch(err) {
     console.error('[ERROR] WITH SPEC FILE: ', path);
-    console.error(err);
+    console.error(err.message);
   }
 });

--- a/lib/karma.test_runner.js
+++ b/lib/karma.test_runner.js
@@ -21,7 +21,6 @@ _.filter(context.keys(), filter).forEach(function(path) {
   try {
     context(path);
   } catch(err) {
-    console.error('[ERROR] WITH SPEC FILE: ', path);
-    console.error(err.message);
+    console.error(err.name + ': "' + err.message + '" from ' + path);
   }
 });

--- a/lib/karma.test_runner.js
+++ b/lib/karma.test_runner.js
@@ -22,5 +22,6 @@ _.filter(context.keys(), filter).forEach(function(path) {
     context(path);
   } catch(err) {
     console.error(err.name + ': "' + err.message + '" from ' + path);
+    throw err;
   }
 });


### PR DESCRIPTION
When installing this into HI, I noticed that `console.error(err)` isn't very useful.
before:
```
Chrome 54.0.2840 (Mac OS X 10.10.5) ERROR: '[ERROR] WITH SPEC FILE: ', './components/shared/fulfillment/re_open_enrolment_wizard_spec.jsx'
Chrome 54.0.2840 (Mac OS X 10.10.5) ERROR: Error{}
```

after:
```
Chrome 54.0.2840 (Mac OS X 10.10.5) ERROR: 'Error: "No source available" from ./components/shared/fulfillment/re_open_enrolment_wizard_spec.jsx'
```

It will also show the specific error class if not just `Error`.