### PR TITLE
Fix Enzyme Warnings, Stop Tests Running on Error

### DIFF
--- a/bin/gusto-karma.sh
+++ b/bin/gusto-karma.sh
@@ -4,15 +4,15 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 case "$1" in
   'test')
     echo 'Running Gusto-Karma Tests..'
-    karma start node_modules/gusto-karma/lib/karma.config.js ${@:2:$#}
+    karma start node_modules/@gusto/gusto-karma/lib/karma.config.js ${@:2:$#}
     ;;
   'server')
     echo 'Starting Gusto-Karma Server..'
-    karma start node_modules/gusto-karma/lib/karma.config.js --no-single-run ${@:2:$#}
+    karma start node_modules/@gusto/gusto-karma/lib/karma.config.js --no-single-run ${@:2:$#}
     ;;
   'run')
     echo "Running Gusto-Karma Tests for ${2}.."
-    karma run node_modules/gusto-karma/lib/karma.config.js  -- $2
+    karma run node_modules/@gusto/gusto-karma/lib/karma.config.js  -- $2
     ;;
   *)
     echo 'Usage gusto-karma (test|server|run)'

--- a/lib/karma.config.js
+++ b/lib/karma.config.js
@@ -17,6 +17,9 @@ webpackConfig.progress = false;
 webpackConfig.resolve.extensions.push('.json');
 webpackConfig.externals || (webpackConfig.externals = {});
 webpackConfig.externals.jsdom = 'window';
+webpackConfig.externals['react-dom'] = true;
+webpackConfig.externals['react-dom/server'] = true;
+webpackConfig.externals['react-addons-test-utils'] = true;
 webpackConfig.node = {
   __dirname: true,
   __filename: true
@@ -47,6 +50,21 @@ var config = function(config) {
       FIXTURES: !!options.fixtures
     })
   );
+
+  webpackConfig.plugins.push(function () {
+    this.plugin('done', function (stats) {
+      if (stats.compilation.warnings.length) {
+        // Pretend no assets were generated. This prevents the tests
+        // from running making it clear that there were warnings.
+        stats.stats = [{
+          toJson: function() {
+            return this;
+          },
+          assets: []
+        }];
+      }
+    });
+});
 
   config.set({
     frameworks: [

--- a/lib/karma.test_runner.js
+++ b/lib/karma.test_runner.js
@@ -21,7 +21,7 @@ _.filter(context.keys(), filter).forEach(function(path) {
   try {
     context(path);
   } catch(err) {
-    console.error('[ERROR] WITH SPEC FILE: ', path);
-    console.error(err);
+    console.error('[ERROR]: ', path);
+    throw err;
   }
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/gusto-karma",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Wrapper around karma for usage at Gusto",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This fixes the enzyme warnings and also prevents webpack from compiling other files when there is an error in one (which usually removes an `.only` and causes the whole suite to run).

cc @AlexEvanczuk 