### PR TITLE
Add toast reporter for Karma

### DIFF
--- a/lib/gusto-karma.config.js
+++ b/lib/gusto-karma.config.js
@@ -5,6 +5,7 @@ var paths = require('./utils/path');
 var ROOT_DIR = paths.ROOT_DIR;
 var SPEC_DIR = paths.SPEC_DIR;
 var browserConfig = require('./utils/browsers');
+var toastPlugin = require('./utils/toastReporter');
 
 var webpackConfig = require(path.join(ROOT_DIR, 'webpack.config.js'));
 var karmaConfig = require(path.join(SPEC_DIR, 'karma.config'));
@@ -89,9 +90,19 @@ module.exports = function(config) {
 
   config.set(browserConfig);
 
+  var reporters = ['mocha']
+  var plugins = config.plugins;
+  if (IN_CI) {
+    reporters.push('junit');
+  } else {
+    plugins.push(toastPlugin);
+    reporters.push('toast');
+  }
+
   config.set({
     singleRun: true,
-    reporters: IN_CI ? ['mocha', 'junit'] : ['mocha'],
+    plugins: plugins,
+    reporters: reporters,
     mochaReporter: {
       showDiff: true,
       output: 'minimal'

--- a/lib/gusto-karma.config.js
+++ b/lib/gusto-karma.config.js
@@ -5,7 +5,7 @@ var paths = require('./utils/path');
 var ROOT_DIR = paths.ROOT_DIR;
 var SPEC_DIR = paths.SPEC_DIR;
 var browserConfig = require('./utils/browsers');
-var toastPlugin = require('./utils/toastReporter');
+var toastPlugin = require('./utils/toast_reporter');
 
 var webpackConfig = require(path.join(ROOT_DIR, 'webpack.config.js'));
 var karmaConfig = require(path.join(SPEC_DIR, 'karma.config'));

--- a/lib/utils/toast_reporter.js
+++ b/lib/utils/toast_reporter.js
@@ -1,0 +1,36 @@
+var notifier = require('node-notifier');
+
+var ToastReporter = function(baseReporterDecorator) {
+  baseReporterDecorator(this);
+
+  this.onRunComplete = function(browsers, results) {
+    var sym;
+    var count;
+    if (results.success + results.failed === 0) {
+      sym = '🤔';
+      count = 'No tests ran';
+    } else if (results.failed) {
+      sym = '❌';
+      s = results.success === 1 ? '' : 's'
+      count = `${results.success} test${s} passed, ${results.failed} failed`;
+    } else {
+      sym = '✅';
+      count = `${results.success} tests passed`;
+    }
+
+    var totalMs = browsers.map(b => b.lastResult.totalTime).reduce((x, y) => x + y);
+    var totalSecs = Math.ceil(totalMs / 1000);
+    var secs = totalSecs % 60;
+    if (secs < 10) { secs = `0${secs}`; }
+    var mins = Math.floor(totalSecs / 60);
+    var time = `${mins}:${secs}`;
+
+    notifier.notify({
+      title: `${sym} Gusto-Karma`,
+      message: `${count} in ${time}`
+    });
+  };
+};
+ToastReporter.$inject = ['baseReporterDecorator'];
+
+module.exports = {'reporter:toast': ['type', ToastReporter]};

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "1.7.0",
     "mocha": "3.2.0",
+    "node-notifier": "^5.0.2",
     "phantomjs-prebuilt": "2.1.13",
     "sinon": "1.17.5",
     "sinon-chai": "2.8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/gusto-karma",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Wrapper around karma for usage at Gusto",
   "main": "index.js",
   "bin": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -30,7 +30,7 @@ ansi-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.0.0.tgz#c5061b6e0ef8a81775e50f5d66151bf6bf371107"
 
-ansi-styles@^2.1.0, ansi-styles@^2.2.1:
+ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
@@ -226,21 +226,11 @@ chai@3.5.0:
     deep-eql "^0.1.3"
     type-detect "^1.0.0"
 
-chalk@1.1.3:
+chalk@1.1.3, chalk@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
     ansi-styles "^2.2.1"
-    escape-string-regexp "^1.0.2"
-    has-ansi "^2.0.0"
-    strip-ansi "^3.0.0"
-    supports-color "^2.0.0"
-
-chalk@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.1.tgz#509afb67066e7499f7eb3535c77445772ae2d019"
-  dependencies:
-    ansi-styles "^2.1.0"
     escape-string-regexp "^1.0.2"
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
@@ -413,13 +403,9 @@ es6-promise@~4.0.3:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.0.5.tgz#7882f30adde5b240ccfa7f7d78c548330951ae42"
 
-escape-string-regexp@1.0.5:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-
-escape-string-regexp@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
 
 events@^1.0.0:
   version "1.1.1"
@@ -603,20 +589,9 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@7.0.5:
+glob@7.0.5, glob@^7.0.5:
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.5.tgz#b4202a69099bbb4d292a7c1b95b6682b67ebdc95"
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.2"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.5:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -636,6 +611,10 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6:
 growl@1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.9.2.tgz#0ea7743715db8d8de2c5ede1775e1b45ac85c02f"
+
+growly@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
 
 har-validator@~2.0.6:
   version "2.0.6"
@@ -1155,6 +1134,15 @@ node-libs-browser@^0.6.0:
     util "~0.10.3"
     vm-browserify "0.0.4"
 
+node-notifier@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.0.2.tgz#4438449fe69e321f941cef943986b0797032701b"
+  dependencies:
+    growly "^1.3.0"
+    semver "^5.3.0"
+    shellwords "^0.1.0"
+    which "^1.2.12"
+
 node-pre-gyp@^0.6.29:
   version "0.6.31"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.31.tgz#d8a00ddaa301a940615dbcc8caad4024d58f6017"
@@ -1479,7 +1467,7 @@ samsam@1.1.2, samsam@~1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.1.2.tgz#bec11fdc83a9fda063401210e40176c3024d1567"
 
-semver@~5.3.0:
+semver@^5.3.0, semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
@@ -1494,6 +1482,10 @@ set-immediate-shim@^1.0.1:
 sha.js@2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.2.6.tgz#17ddeddc5f722fb66501658895461977867315ba"
+
+shellwords@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.0.tgz#66afd47b6a12932d9071cbfd98a52e785cd0ba14"
 
 signal-exit@^3.0.0:
   version "3.0.1"
@@ -1752,6 +1744,12 @@ webpack@1:
 which@^1.2.1, which@~1.2.10:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.11.tgz#c8b2eeea6b8c1659fa7c1dd4fdaabe9533dc5e8b"
+  dependencies:
+    isexe "^1.1.1"
+
+which@^1.2.12:
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz#de67b5e450269f194909ef23ece4ebe416fa1192"
   dependencies:
     isexe "^1.1.1"
 


### PR DESCRIPTION
Provides helpful status messages to devs when their builds pass/fail in the background:

<img width="363" alt="pass" src="https://cloud.githubusercontent.com/assets/1829094/23811259/79fb659a-0592-11e7-9b43-1594de9b1129.png">
<img width="365" alt="fail" src="https://cloud.githubusercontent.com/assets/1829094/23811258/79ee9676-0592-11e7-8cf7-64815c574b3d.png">
<img width="359" alt="none" src="https://cloud.githubusercontent.com/assets/1829094/23811260/79fdd870-0592-11e7-86e0-e47d11cc3e65.png">

Ready for review.

# TODO

- [x] Smoke test locally
- [ ] Verify that this actually works on Linux
- [x] Test the config to ensure it doesn't break CI
- [ ] Cut a new version for npm
