### PR TITLE
config: development overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install Gusto-Karma along with Gusto-Webpack and it will provide several command
 - *`gusto-karma run <file>`* - If a test server is running, runs the tests for files matching the `<file>` path. Especially helpful when running the server with the `--no-auto-watch` flag.
 
 Add a `karma.config.js` in `frontend/javascripts/spec` to configure specific Karma options and to configure:
-```
+```js
 module.exports = function (config) {
   config.set({
     gustoKarma: {
@@ -30,4 +30,30 @@ module.exports = function (config) {
 - It will load all files containing `_spec` in `frontend/javascripts/spec` with the `webpack` and `sourcemap` Karma preprocessors.
 
 #### In CI
-When running in CI, Gusto-Karma will output both `mocha` and `junit` test results.
+When running in CI (`env.IN_CI`), Gusto-Karma will output both `mocha` and `junit` test results.
+
+#### Per-Project Config
+Individual projects can configure Gusto-Karma in `frontend/javascripts/spec/karma.config.js`.
+
+#### Developer Config
+Developers can configure Gusto-Karma for their machine in `karma.config.development_override.js`. This file is optional.
+
+Options developers might want to set:
+- `gustoKarma.desktopNotifications`: set to `false` to disable desktop notifications when tests complete
+  - You can also set the environment variable `NO_NOTIF=TRUE` to disable notifications
+
+When you add Gusto-Karma to your project, do the following:
+- Add `frontend/javascripts/spec/karma.config.development_override.js` to your project's gitignore
+- Commit this template to your repo as `frontend/javascripts/spec/karma.config.development_override.js.sample`:
+
+```js
+// Use this file to configure Gusto-Karma with your machine-specific overrides.
+
+module.exports = function(config) {
+  config.set({
+    gustoKarma: {
+      desktopNotifications: false
+    }
+  });
+};
+```

--- a/lib/gusto-karma.config.js
+++ b/lib/gusto-karma.config.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var fs = require('fs');
 var env = require('./utils/environment.js');
 var IN_CI = env.IN_CI;
 var NO_NOTIF = env.NO_NOTIF;

--- a/lib/gusto-karma.config.js
+++ b/lib/gusto-karma.config.js
@@ -1,6 +1,8 @@
 var path = require('path');
+var fs = require('fs');
 var env = require('./utils/environment.js');
 var IN_CI = env.IN_CI;
+var NO_NOTIF = env.NO_NOTIF;
 var paths = require('./utils/path');
 var ROOT_DIR = paths.ROOT_DIR;
 var SPEC_DIR = paths.SPEC_DIR;
@@ -9,6 +11,17 @@ var toastPlugin = require('./utils/toast_reporter');
 
 var webpackConfig = require(path.join(ROOT_DIR, 'webpack.config.js'));
 var karmaConfig = require(path.join(SPEC_DIR, 'karma.config'));
+
+var karmaDevConfig;
+try {
+  karmaDevConfig = require(path.join(SPEC_DIR, 'karma.config.development_override'));
+} catch (e) {
+  if (e instanceof Error && e.code === 'MODULE_NOT_FOUND') {
+    // do nothing */
+  } else {
+    throw e;
+  }
+}
 
 // Enzyme Patch https://github.com/airbnb/enzyme/issues/47
 // https://github.com/webpack/webpack/issues/184
@@ -26,8 +39,16 @@ webpackConfig.node = {
   __filename: true
 };
 
+function toastEnabled(config) {
+  if (IN_CI) { return false; }
+  if (NO_NOTIF) { return false; }
+  if (config.gustoKarma && config.gustoKarma.desktopNotifications === false) { return false; }
+  return true;
+}
+
 module.exports = function(config) {
   karmaConfig(config);
+  if (karmaDevConfig) { karmaDevConfig(config); }
 
   var options = config.gustoKarma || {};
 
@@ -65,7 +86,7 @@ module.exports = function(config) {
         }];
       }
     });
-});
+  });
 
   config.set({
     frameworks: [
@@ -92,9 +113,12 @@ module.exports = function(config) {
 
   var reporters = ['mocha']
   var plugins = config.plugins;
+
   if (IN_CI) {
     reporters.push('junit');
-  } else {
+  }
+
+  if (toastEnabled(config)) {
     plugins.push(toastPlugin);
     reporters.push('toast');
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/gusto-karma",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Wrapper around karma for usage at Gusto",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Multiple developers have requested an opt-out of the toast-on-test-complete behavior. Some people find it annoying with the way they are running tests. Robbie suggested we add a `development_override` config similar to the one in ZP.

This adds the following:

* Optional `karma.config.development_override.js`
* `NO_NOTIF=TRUE` env and `gustoKarma.desktopNotifications = false` opt-outs
* Docs, config option details, and sample config for your project
* Version bump

Tested locally, works on my machine. To test on yours:

* cd into `zenpayroll` project
* `git pull` onto latest `development`
* run the following in order:

```sh
rm -rf node_modules
yarn cache clean
yarn run webpack-clear-cache
yarn add file:/users/YOUR_USERNAME/SOME_PATH_TO/gusto-karma
yarn install
yarn run test
```

Try running with the following:
* `IN_CI=TRUE`
* `NO_NOTIF=TRUE`
* create `frontend/javascripts/spec/karma.config.development_override.js` with `gustoKarma.desktopNotifications = false`