### PR TITLE
add bdd-lazy-var with config

### DIFF
--- a/lib/gusto-karma.config.js
+++ b/lib/gusto-karma.config.js
@@ -135,6 +135,13 @@ module.exports = function(config) {
     webpackServer: {
       noInfo: true,
       stats: 'errors-only'
+    },
+    // bdd-lazy-var - see config options at https://github.com/stalniy/bdd-lazy-var
+    client: {
+      mocha: {
+        ui: 'bdd-lazy-var/getter',
+        require: [require.resolve('bdd-lazy-var/bdd_lazy_var_getter')]
+      }
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/gusto-karma",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Wrapper around karma for usage at Gusto",
   "main": "index.js",
   "bin": {
@@ -12,6 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "bdd-lazy-var": "^1.2.1",
     "chai": "3.5.0",
     "karma-chai": "0.1.0",
     "karma-chrome-launcher": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -140,6 +140,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bdd-lazy-var@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/bdd-lazy-var/-/bdd-lazy-var-1.2.1.tgz#7e2148050f07921728cb1c024409b81a37c6c35e"
+
 big.js@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
@@ -1741,13 +1745,13 @@ webpack@1:
     watchpack "^0.2.1"
     webpack-core "~0.6.0"
 
-which@^1.2.1, which@~1.2.10:
+which@^1.2.1:
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.11.tgz#c8b2eeea6b8c1659fa7c1dd4fdaabe9533dc5e8b"
   dependencies:
     isexe "^1.1.1"
 
-which@^1.2.12:
+which@^1.2.12, which@~1.2.10:
   version "1.2.12"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.12.tgz#de67b5e450269f194909ef23ece4ebe416fa1192"
   dependencies:


### PR DESCRIPTION
[bdd-lazy-var](https://github.com/stalniy/bdd-lazy-var) helps us write concise tests with lazy vars. It's reminiscent to rspec style if you're a fan of that.

# Why add this now?

I wrote lots of tests for React component state recently. I'd like to port some of those tests to lazy-var style. I want to use them as teaching tools and show people how lazy vars can improve their tests.

# Example spec

```js
class User {
  constructor(name, loc) {
    this._name = name;
    this.loc = loc;
    this.enabled = true;
    this.goldMember = false;
  }

  get name() {
    if (!this.enabled) { return '[disabled]'; }
    if (this.goldMember) { return `${this._name} (gold)`; }
    return this._name;
  }

  inSF() {
    return this.loc.includes('San Francisco');
  }
}

describe.only('User class', function() {
  subject('user', () => new User('Jimmy John', get.loc));
  def('loc', 'Denver, CO');

  it('has the proper defaults', () => {
    expect(get.subject.name).to.eql('Jimmy John');
    expect(get.subject.enabled).to.be.true;
    expect(get.subject.goldMember).to.be.false;
  });

  it('is not located in SF', () => {
    expect(get.subject.inSF()).to.be.false;
  });

  context('when user is a gold member', () => {
    beforeEach(() => { get.subject.goldMember = true; });

    it('shows the name with gold status', () => {
      expect(get.subject.name).to.eql('Jimmy John (gold)');
    });
  });

  context('when disabled', () => {
    beforeEach(() => { get.subject.enabled = false; });

    it('does not display the name', () => {
      expect(get.subject.name).to.eql('[disabled]');
    });

    context('when user is a gold member', () => {
      beforeEach(() => { get.subject.goldMember = true; });

      it('still does not display the name', () => {
        expect(get.subject.name).to.eql('[disabled]');
      });
    });
  });

  context('in SF', () => {
    def('loc', 'San Francisco, CA');

    it('is located in SF', () => {
      expect(get.subject.inSF()).to.be.true;
    });
  });
});
```

# Linter config

This config registers the bdd-lazy-var globals with ESLint so it knows they exist in our test suite. It also prevents them from being inadvertently overwritten by people writing tests.

Add the following to `zenpayroll/frontend/javascripts/spec/.eslintrc`:

```js
{
  "globals": {
    "def": false,
    "get": false,
    "subject": false,
    "$subject": false
  }
}
```

# How to test

1. Checkout this branch in `gusto-karma`.
2. Put the example spec above into `zenpayroll/frontend/javascripts/spec/bdd_lazy_spec.js`.
3. Run the following in `zenpayroll`:

```sh
rm -rf node_modules
yarn cache clean
yarn run webpack-clear-cache
yarn add file:/users/YOUR_USERNAME/SOME_PATH_TO/gusto-karma
yarn install
yarn run test
```

# Why *getter* style?

There are four styles available in [bdd-lazy-var](https://github.com/stalniy/bdd-lazy-var). They change the way we access our lazy vars.

Say we set a variable:

```js
def('myUser', () => new User('matt! hooray'));
```

Here's how each style accesses this var:

* vanilla: `get('myUser')`
* getter: `get.myUser`
* global, rspec: `$myUser`

Getter style is cleaner than vanilla string-getter style. We can't use global/rspec style because ESLint doesn't support wildcard-named globals. Otherwise I'd prefer the concise `$varName` style.