### PR TITLE
Allow projects to override reporters via config

### DIFF
--- a/lib/gusto-karma.config.js
+++ b/lib/gusto-karma.config.js
@@ -108,7 +108,7 @@ module.exports = function(config) {
 
   config.set(browserConfig);
 
-  var reporters = ['mocha']
+  var reporters = ['mocha'].concat(config.reporters || []);
   var plugins = config.plugins;
 
   if (IN_CI) {


### PR DESCRIPTION
We do this for plugins, frameworks, preprocessors, and files. I think this was just an oversight for reporters.