### PR TITLE
Log errors when webpack finishes with errors to clarify why tests are hanging

### DIFF
--- a/lib/gusto-karma.config.js
+++ b/lib/gusto-karma.config.js
@@ -72,6 +72,10 @@ module.exports = function(config) {
   webpackConfig.plugins.push(function () {
     this.plugin('done', function (stats) {
       if (stats.compilation.warnings.length) {
+        // Log each of the warnings so it is clear why tests are hanging
+        stats.compilation.warnings.forEach(function (warning) {
+          console.log(warning.message || warning);
+        });
         // Pretend no assets were generated. This prevents the tests
         // from running making it clear that there were warnings.
         stats.stats = [{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/gusto-karma",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Wrapper around karma for usage at Gusto",
   "main": "index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/gusto-karma",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Wrapper around karma for usage at Gusto",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This change intends to fix developer confusion around hanging tests due to webpack failing to build all modules properly.

# Before
<img width="538" alt="screen shot 2017-10-17 at 11 44 49 pm" src="https://user-images.githubusercontent.com/3311200/31704255-5656eaae-b395-11e7-9ecc-4778bf861421.png">

# After
<img width="674" alt="screen shot 2017-10-17 at 11 43 58 pm" src="https://user-images.githubusercontent.com/3311200/31704266-5e237770-b395-11e7-8fd5-c50576a97265.png">
