### PR TITLE
Enable expose-gc Chrome JS flag based on ENV variable

### DIFF
--- a/lib/utils/browsers.js
+++ b/lib/utils/browsers.js
@@ -13,7 +13,7 @@ function browsersSelection(env, inCI) {
 }
 
 function flags(env) {
-  if (process.env.KARMA_EXPOSE_GC) {
+  if (env.KARMA_EXPOSE_GC) {
     return ['--js-flags="--expose-gc"'];
   } else {
     return [];

--- a/lib/utils/browsers.js
+++ b/lib/utils/browsers.js
@@ -13,7 +13,7 @@ function browsersSelection(env, inCI) {
 }
 
 function flags(env) {
-  if (process.env.CHROME_EXPOSE_GC) {
+  if (process.env.KARMA_EXPOSE_GC) {
     return ['--js-flags="expose-gc"'];
   } else {
     return [];

--- a/lib/utils/browsers.js
+++ b/lib/utils/browsers.js
@@ -14,7 +14,7 @@ function browsersSelection(env, inCI) {
 
 function flags(env) {
   if (process.env.KARMA_EXPOSE_GC) {
-    return ['--js-flags="expose-gc"'];
+    return ['--js-flags="--expose-gc"'];
   } else {
     return [];
   }

--- a/lib/utils/browsers.js
+++ b/lib/utils/browsers.js
@@ -12,16 +12,26 @@ function browsersSelection(env, inCI) {
   }
 }
 
+function flags(env) {
+  if (process.env.CHROME_EXPOSE_GC) {
+    return ['--js-flags="expose-gc"'];
+  } else {
+    return [];
+  }
+}
+
 module.exports = {
   browsers: browsersSelection(process.env, IN_CI),
   customLaunchers: {
     Chrome_with_debugging: {
       base: 'Chrome',
-      chromeDataDir: path.resolve(process.cwd(), 'tmp/.chrome')
+      chromeDataDir: path.resolve(process.cwd(), 'tmp/.chrome'),
+      flags: flags(process.env)
     },
     ChromeHeadless_with_debugging: {
       base: 'ChromeHeadless',
       chromeDataDir: path.resolve(process.cwd(), 'tmp/.chrome_headless'),
+      flags: flags(process.env)
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gusto/gusto-karma",
-  "version": "4.5.7",
+  "version": "4.6.0",
   "description": "Wrapper around karma for usage at Gusto",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
After enabling this, we'll be able to invoke `gc()` in our JS when we please.